### PR TITLE
Fix: GitRepositoryの owner, language をOptionalに修正

### DIFF
--- a/iOSEngineerCodeCheck/GitRepositoryDetailView/GitRepositoryDetailViewController.swift
+++ b/iOSEngineerCodeCheck/GitRepositoryDetailView/GitRepositoryDetailViewController.swift
@@ -30,7 +30,13 @@ class GitRepositoryDetailViewController: UIViewController {
         title = gitRepository.fullName
         view = myView
         
-        myView.languageLabel.text = "Written in \(gitRepository.language)"
+        myView.languageLabel.text = {
+            if let language = gitRepository.language {
+                "Written in \(language)"
+            } else {
+                "No Language"
+            }
+        }()
         myView.starsLabel.text = "\(gitRepository.stargazersCount) stars"
         myView.watchesLabel.text = "\(gitRepository.watchersCount) watchers"
         myView.forksLabel.text = "\(gitRepository.forksCount) forks"
@@ -40,7 +46,7 @@ class GitRepositoryDetailViewController: UIViewController {
     
     func getImage() {
         myView.titleLabel.text = gitRepository.fullName
-        guard let url = URL(string: gitRepository.owner.avatarURL) else { return }
+        guard let owner = gitRepository.owner, let url = URL(string: owner.avatarURL) else { return }
         Task {
             let image = try await ImageFetcher().fetchImage(from: url)
             await MainActor.run {

--- a/iOSEngineerCodeCheck/GitRepositoryListView/GitRepositoryListViewController.swift
+++ b/iOSEngineerCodeCheck/GitRepositoryListView/GitRepositoryListViewController.swift
@@ -71,7 +71,7 @@ extension GitRepositoryListViewController: UITableViewDataSource {
         
         var content = cell.defaultContentConfiguration()
         content.text = gitRepository.fullName
-        content.secondaryText = gitRepository.language
+        content.secondaryText = gitRepository.language ?? "言語なし"
         cell.contentConfiguration = content
         return cell
     }

--- a/iOSEngineerCodeCheck/Model/Entity/GitRepository.swift
+++ b/iOSEngineerCodeCheck/Model/Entity/GitRepository.swift
@@ -19,10 +19,10 @@ struct GitRepository: Decodable {
     let htmlURL: String
     
     /// リポジトリの所有者。
-    let owner: GitRepositoryOwner
+    let owner: GitRepositoryOwner?
     
     /// プロジェクト言語。
-    let language: String
+    let language: String?
     
     /// Star 数。
     let stargazersCount: Int


### PR DESCRIPTION
[GitHubAPIのドキュメント](https://docs.github.com/ja/rest/search/search?apiVersion=2022-11-28#search-repositories) に記載されている応答スキーマを確認し、それぞれのプロパティの型について調べた。

すると、`owner` および `language` は、nullを許容することが判明した。

このままではデコードに失敗する恐れがあるため、この2つをOptional型に修正した。