### PR TITLE
rename: GitRepositoryListViewをGitRepositorySearchViewに改名

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -15,10 +15,10 @@
 		A621C6D32B3CFEF600F0E060 /* SearchSettingPopoverViewElementID.swift in Sources */ = {isa = PBXBuildFile; fileRef = A621C6D22B3CFEF600F0E060 /* SearchSettingPopoverViewElementID.swift */; };
 		A621C6D52B3D162600F0E060 /* SearchSettingPopoverViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A621C6D42B3D162600F0E060 /* SearchSettingPopoverViewDelegate.swift */; };
 		A632347E2B3B14A7000C89C2 /* GitRepositoryDetailViewElementID.swift in Sources */ = {isa = PBXBuildFile; fileRef = A632347D2B3B14A7000C89C2 /* GitRepositoryDetailViewElementID.swift */; };
-		A64CCFA62B3B24E500C19CA6 /* GitRepositoryListViewElementID.swift in Sources */ = {isa = PBXBuildFile; fileRef = A691B1222B3B0F6E0002F405 /* GitRepositoryListViewElementID.swift */; };
-		A6519E922B382FC100335D24 /* GitRepositoryListPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6519E912B382FC100335D24 /* GitRepositoryListPresenter.swift */; };
-		A6519E942B38300700335D24 /* GitRepositoryListPresenterInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6519E932B38300700335D24 /* GitRepositoryListPresenterInput.swift */; };
-		A6519E962B38300F00335D24 /* GitRepositoryListPresenterOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6519E952B38300F00335D24 /* GitRepositoryListPresenterOutput.swift */; };
+		A64CCFA62B3B24E500C19CA6 /* GitRepositorySearchViewElementID.swift in Sources */ = {isa = PBXBuildFile; fileRef = A691B1222B3B0F6E0002F405 /* GitRepositorySearchViewElementID.swift */; };
+		A6519E922B382FC100335D24 /* GitRepositorySearchPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6519E912B382FC100335D24 /* GitRepositorySearchPresenter.swift */; };
+		A6519E942B38300700335D24 /* GitRepositorySearchPresenterInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6519E932B38300700335D24 /* GitRepositorySearchPresenterInput.swift */; };
+		A6519E962B38300F00335D24 /* GitRepositorySearchPresenterOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6519E952B38300F00335D24 /* GitRepositorySearchPresenterOutput.swift */; };
 		A6519E9B2B38526800335D24 /* GitRepositoryDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6519E9A2B38526800335D24 /* GitRepositoryDetailView.swift */; };
 		A660E6B32B3915DA00946D63 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A660E6B22B3915DA00946D63 /* NetworkError.swift */; };
 		A67FBAAB2B3E6EDD003E7A52 /* NSLayoutConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = A67FBAAA2B3E6EDD003E7A52 /* NSLayoutConstraint.swift */; };
@@ -33,13 +33,13 @@
 		A69D7C612B3A65A500DC5637 /* GitRepositorySearchResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = A69D7C602B3A65A500DC5637 /* GitRepositorySearchResult.swift */; };
 		A69D7C642B3A865400DC5637 /* GitRepositorySearcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A69D7C632B3A865400DC5637 /* GitRepositorySearcherTests.swift */; };
 		A6E9BEC72B3A9FA400DF0701 /* MockGitRepositorySearcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E9BEC62B3A9FA400DF0701 /* MockGitRepositorySearcher.swift */; };
-		A6E9BECA2B3AA04100DF0701 /* MockGitRepositoryListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E9BEC92B3AA04100DF0701 /* MockGitRepositoryListViewController.swift */; };
-		A6E9BECC2B3AA24700DF0701 /* GitRepositoryListPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E9BECB2B3AA24700DF0701 /* GitRepositoryListPresenterTests.swift */; };
+		A6E9BECA2B3AA04100DF0701 /* MockGitRepositorySearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E9BEC92B3AA04100DF0701 /* MockGitRepositorySearchViewController.swift */; };
+		A6E9BECC2B3AA24700DF0701 /* GitRepositorySearchPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E9BECB2B3AA24700DF0701 /* GitRepositorySearchPresenterTests.swift */; };
 		A6E9BECF2B3AA47900DF0701 /* DummyGitRepositoryMaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E9BECE2B3AA47900DF0701 /* DummyGitRepositoryMaker.swift */; };
 		BF0A658D244F2A3B00280FA6 /* GitRepositoryDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0A658C244F2A3B00280FA6 /* GitRepositoryDetailViewController.swift */; };
 		BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945DE244DC5E80012785A /* AppDelegate.swift */; };
 		BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E0244DC5E80012785A /* SceneDelegate.swift */; };
-		BFD945E3244DC5E80012785A /* GitRepositoryListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E2244DC5E80012785A /* GitRepositoryListViewController.swift */; };
+		BFD945E3244DC5E80012785A /* GitRepositorySearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD945E2244DC5E80012785A /* GitRepositorySearchViewController.swift */; };
 		BFD945E8244DC5EB0012785A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BFD945E7244DC5EB0012785A /* Assets.xcassets */; };
 		BFD945EB244DC5EB0012785A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BFD945E9244DC5EB0012785A /* LaunchScreen.storyboard */; };
 		BFD94601244DC5EC0012785A /* iOSEngineerCodeCheckUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD94600244DC5EC0012785A /* iOSEngineerCodeCheckUITests.swift */; };
@@ -71,14 +71,14 @@
 		A621C6D22B3CFEF600F0E060 /* SearchSettingPopoverViewElementID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSettingPopoverViewElementID.swift; sourceTree = "<group>"; };
 		A621C6D42B3D162600F0E060 /* SearchSettingPopoverViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSettingPopoverViewDelegate.swift; sourceTree = "<group>"; };
 		A632347D2B3B14A7000C89C2 /* GitRepositoryDetailViewElementID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRepositoryDetailViewElementID.swift; sourceTree = "<group>"; };
-		A6519E912B382FC100335D24 /* GitRepositoryListPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRepositoryListPresenter.swift; sourceTree = "<group>"; };
-		A6519E932B38300700335D24 /* GitRepositoryListPresenterInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRepositoryListPresenterInput.swift; sourceTree = "<group>"; };
-		A6519E952B38300F00335D24 /* GitRepositoryListPresenterOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRepositoryListPresenterOutput.swift; sourceTree = "<group>"; };
+		A6519E912B382FC100335D24 /* GitRepositorySearchPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRepositorySearchPresenter.swift; sourceTree = "<group>"; };
+		A6519E932B38300700335D24 /* GitRepositorySearchPresenterInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRepositorySearchPresenterInput.swift; sourceTree = "<group>"; };
+		A6519E952B38300F00335D24 /* GitRepositorySearchPresenterOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRepositorySearchPresenterOutput.swift; sourceTree = "<group>"; };
 		A6519E9A2B38526800335D24 /* GitRepositoryDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRepositoryDetailView.swift; sourceTree = "<group>"; };
 		A660E6B22B3915DA00946D63 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		A67FBAAA2B3E6EDD003E7A52 /* NSLayoutConstraint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSLayoutConstraint.swift; sourceTree = "<group>"; };
 		A67FBAAC2B3E876A003E7A52 /* UIColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColor.swift; sourceTree = "<group>"; };
-		A691B1222B3B0F6E0002F405 /* GitRepositoryListViewElementID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRepositoryListViewElementID.swift; sourceTree = "<group>"; };
+		A691B1222B3B0F6E0002F405 /* GitRepositorySearchViewElementID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRepositorySearchViewElementID.swift; sourceTree = "<group>"; };
 		A69765202B37C6C2001B8136 /* GitRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRepository.swift; sourceTree = "<group>"; };
 		A69765222B37D094001B8136 /* GitRepositorySearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRepositorySearcher.swift; sourceTree = "<group>"; };
 		A69765242B37D545001B8136 /* GitRepositoryOwner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRepositoryOwner.swift; sourceTree = "<group>"; };
@@ -88,14 +88,14 @@
 		A69D7C602B3A65A500DC5637 /* GitRepositorySearchResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRepositorySearchResult.swift; sourceTree = "<group>"; };
 		A69D7C632B3A865400DC5637 /* GitRepositorySearcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRepositorySearcherTests.swift; sourceTree = "<group>"; };
 		A6E9BEC62B3A9FA400DF0701 /* MockGitRepositorySearcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGitRepositorySearcher.swift; sourceTree = "<group>"; };
-		A6E9BEC92B3AA04100DF0701 /* MockGitRepositoryListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGitRepositoryListViewController.swift; sourceTree = "<group>"; };
-		A6E9BECB2B3AA24700DF0701 /* GitRepositoryListPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRepositoryListPresenterTests.swift; sourceTree = "<group>"; };
+		A6E9BEC92B3AA04100DF0701 /* MockGitRepositorySearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGitRepositorySearchViewController.swift; sourceTree = "<group>"; };
+		A6E9BECB2B3AA24700DF0701 /* GitRepositorySearchPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRepositorySearchPresenterTests.swift; sourceTree = "<group>"; };
 		A6E9BECE2B3AA47900DF0701 /* DummyGitRepositoryMaker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyGitRepositoryMaker.swift; sourceTree = "<group>"; };
 		BF0A658C244F2A3B00280FA6 /* GitRepositoryDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRepositoryDetailViewController.swift; sourceTree = "<group>"; };
 		BFD945DB244DC5E80012785A /* iOSEngineerCodeCheck.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSEngineerCodeCheck.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFD945DE244DC5E80012785A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BFD945E0244DC5E80012785A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		BFD945E2244DC5E80012785A /* GitRepositoryListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRepositoryListViewController.swift; sourceTree = "<group>"; };
+		BFD945E2244DC5E80012785A /* GitRepositorySearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitRepositorySearchViewController.swift; sourceTree = "<group>"; };
 		BFD945E7244DC5EB0012785A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		BFD945EA244DC5EB0012785A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		BFD945EC244DC5EB0012785A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -152,16 +152,16 @@
 			path = SearchSettingPopoverView;
 			sourceTree = "<group>";
 		};
-		A6519E902B382E3800335D24 /* GitRepositoryListView */ = {
+		A6519E902B382E3800335D24 /* GitRepositorySearchView */ = {
 			isa = PBXGroup;
 			children = (
-				BFD945E2244DC5E80012785A /* GitRepositoryListViewController.swift */,
-				A6519E932B38300700335D24 /* GitRepositoryListPresenterInput.swift */,
-				A6519E912B382FC100335D24 /* GitRepositoryListPresenter.swift */,
-				A6519E952B38300F00335D24 /* GitRepositoryListPresenterOutput.swift */,
-				A691B1222B3B0F6E0002F405 /* GitRepositoryListViewElementID.swift */,
+				BFD945E2244DC5E80012785A /* GitRepositorySearchViewController.swift */,
+				A6519E932B38300700335D24 /* GitRepositorySearchPresenterInput.swift */,
+				A6519E912B382FC100335D24 /* GitRepositorySearchPresenter.swift */,
+				A6519E952B38300F00335D24 /* GitRepositorySearchPresenterOutput.swift */,
+				A691B1222B3B0F6E0002F405 /* GitRepositorySearchViewElementID.swift */,
 			);
-			path = GitRepositoryListView;
+			path = GitRepositorySearchView;
 			sourceTree = "<group>";
 		};
 		A6519E972B38516600335D24 /* GitRepositoryDetailView */ = {
@@ -251,7 +251,7 @@
 		A6E9BEC82B3A9FD500DF0701 /* View */ = {
 			isa = PBXGroup;
 			children = (
-				A6E9BEC92B3AA04100DF0701 /* MockGitRepositoryListViewController.swift */,
+				A6E9BEC92B3AA04100DF0701 /* MockGitRepositorySearchViewController.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -289,7 +289,7 @@
 			children = (
 				A697651F2B37C6B6001B8136 /* Model */,
 				A69D7C5A2B39518E00DC5637 /* View */,
-				A6519E902B382E3800335D24 /* GitRepositoryListView */,
+				A6519E902B382E3800335D24 /* GitRepositorySearchView */,
 				A621C6CD2B3CFD8D00F0E060 /* SearchSettingPopoverView */,
 				A6519E972B38516600335D24 /* GitRepositoryDetailView */,
 				A67FBAA52B3E6E9C003E7A52 /* Extension */,
@@ -308,7 +308,7 @@
 			children = (
 				A6E9BEC42B3A9F8D00DF0701 /* Dummy */,
 				A69D7C632B3A865400DC5637 /* GitRepositorySearcherTests.swift */,
-				A6E9BECB2B3AA24700DF0701 /* GitRepositoryListPresenterTests.swift */,
+				A6E9BECB2B3AA24700DF0701 /* GitRepositorySearchPresenterTests.swift */,
 				BFD945F7244DC5EB0012785A /* Info.plist */,
 			);
 			path = iOSEngineerCodeCheckTests;
@@ -462,7 +462,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BFD945E3244DC5E80012785A /* GitRepositoryListViewController.swift in Sources */,
+				BFD945E3244DC5E80012785A /* GitRepositorySearchViewController.swift in Sources */,
 				A621C6C92B3C622D00F0E060 /* GitRepositorySortOption.swift in Sources */,
 				A621C6D52B3D162600F0E060 /* SearchSettingPopoverViewDelegate.swift in Sources */,
 				A67FBAAB2B3E6EDD003E7A52 /* NSLayoutConstraint.swift in Sources */,
@@ -475,18 +475,18 @@
 				A69D7C612B3A65A500DC5637 /* GitRepositorySearchResult.swift in Sources */,
 				BF0A658D244F2A3B00280FA6 /* GitRepositoryDetailViewController.swift in Sources */,
 				A69D7C5C2B3951CB00DC5637 /* NoResultView.swift in Sources */,
-				A6519E922B382FC100335D24 /* GitRepositoryListPresenter.swift in Sources */,
+				A6519E922B382FC100335D24 /* GitRepositorySearchPresenter.swift in Sources */,
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
-				A64CCFA62B3B24E500C19CA6 /* GitRepositoryListViewElementID.swift in Sources */,
+				A64CCFA62B3B24E500C19CA6 /* GitRepositorySearchViewElementID.swift in Sources */,
 				A69765252B37D545001B8136 /* GitRepositoryOwner.swift in Sources */,
 				A621C6CF2B3CFDAD00F0E060 /* SearchSettingPopoverViewController.swift in Sources */,
 				A69765232B37D094001B8136 /* GitRepositorySearcher.swift in Sources */,
 				BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */,
-				A6519E942B38300700335D24 /* GitRepositoryListPresenterInput.swift in Sources */,
+				A6519E942B38300700335D24 /* GitRepositorySearchPresenterInput.swift in Sources */,
 				A69D7C5F2B3A653600DC5637 /* GitRepositorySearcherProtocol.swift in Sources */,
 				A67FBAAD2B3E876A003E7A52 /* UIColor.swift in Sources */,
 				A697652A2B37EFF3001B8136 /* ImageFetcher.swift in Sources */,
-				A6519E962B38300F00335D24 /* GitRepositoryListPresenterOutput.swift in Sources */,
+				A6519E962B38300F00335D24 /* GitRepositorySearchPresenterOutput.swift in Sources */,
 				A660E6B32B3915DA00946D63 /* NetworkError.swift in Sources */,
 				A621C6C12B3C051300F0E060 /* AppColor.swift in Sources */,
 			);
@@ -498,9 +498,9 @@
 			files = (
 				A6E9BECF2B3AA47900DF0701 /* DummyGitRepositoryMaker.swift in Sources */,
 				A69D7C642B3A865400DC5637 /* GitRepositorySearcherTests.swift in Sources */,
-				A6E9BECA2B3AA04100DF0701 /* MockGitRepositoryListViewController.swift in Sources */,
+				A6E9BECA2B3AA04100DF0701 /* MockGitRepositorySearchViewController.swift in Sources */,
 				A6E9BEC72B3A9FA400DF0701 /* MockGitRepositorySearcher.swift in Sources */,
-				A6E9BECC2B3AA24700DF0701 /* GitRepositoryListPresenterTests.swift in Sources */,
+				A6E9BECC2B3AA24700DF0701 /* GitRepositorySearchPresenterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOSEngineerCodeCheck/GitRepositorySearchView/GitRepositorySearchPresenter.swift
+++ b/iOSEngineerCodeCheck/GitRepositorySearchView/GitRepositorySearchPresenter.swift
@@ -1,5 +1,5 @@
 //
-//  GitRepositoryListPresenter.swift
+//  GitRepositorySearchPresenter.swift
 //  iOSEngineerCodeCheck
 //  
 //  Created by Seigetsu on 2023/12/24
@@ -9,9 +9,9 @@
 import Foundation
 import Combine
 
-final class GitRepositoryListPresenter {
+final class GitRepositorySearchPresenter {
     // MARK: 依存
-    private weak var view: GitRepositoryListPresenterOutput!
+    private weak var view: GitRepositorySearchPresenterOutput!
     private let gitRepositorySearcher: GitRepositorySearcherProtocol
     
     // MARK: 状態
@@ -22,7 +22,7 @@ final class GitRepositoryListPresenter {
     private var textDidSearch: String?
     
     // MARK: メソッド
-    init(view: GitRepositoryListPresenterOutput, gitRepositorySearcher: GitRepositorySearcherProtocol) {
+    init(view: GitRepositorySearchPresenterOutput, gitRepositorySearcher: GitRepositorySearcherProtocol) {
         self.view = view
         self.gitRepositorySearcher = gitRepositorySearcher
     }
@@ -90,7 +90,7 @@ final class GitRepositoryListPresenter {
     }
 }
 
-extension GitRepositoryListPresenter: GitRepositoryListPresenterInput {
+extension GitRepositorySearchPresenter: GitRepositorySearchPresenterInput {
     func didSelectSortOption(_ sortOption: GitRepositorySortOption) {
         self.sortOption = sortOption
         searchingTask?.cancel()

--- a/iOSEngineerCodeCheck/GitRepositorySearchView/GitRepositorySearchPresenterInput.swift
+++ b/iOSEngineerCodeCheck/GitRepositorySearchView/GitRepositorySearchPresenterInput.swift
@@ -1,5 +1,5 @@
 //
-//  GitRepositoryListPresenterInput.swift
+//  GitRepositorySearchPresenterInput.swift
 //  iOSEngineerCodeCheck
 //  
 //  Created by Seigetsu on 2023/12/24
@@ -8,7 +8,7 @@
 
 import Foundation
 
-protocol GitRepositoryListPresenterInput {
+protocol GitRepositorySearchPresenterInput {
     /// 画面に表示するための Git リポジトリの配列。
     var gitRepositories: [GitRepository] { get }
     

--- a/iOSEngineerCodeCheck/GitRepositorySearchView/GitRepositorySearchPresenterOutput.swift
+++ b/iOSEngineerCodeCheck/GitRepositorySearchView/GitRepositorySearchPresenterOutput.swift
@@ -1,5 +1,5 @@
 //
-//  GitRepositoryListPresenterOutput.swift
+//  GitRepositorySearchPresenterOutput.swift
 //  iOSEngineerCodeCheck
 //  
 //  Created by Seigetsu on 2023/12/24
@@ -8,7 +8,7 @@
 
 import Foundation
 
-protocol GitRepositoryListPresenterOutput: AnyObject {
+protocol GitRepositorySearchPresenterOutput: AnyObject {
     /// 画面に表示している Git リポジトリの情報を更新する。
     func reloadGitRepositories()
     

--- a/iOSEngineerCodeCheck/GitRepositorySearchView/GitRepositorySearchViewController.swift
+++ b/iOSEngineerCodeCheck/GitRepositorySearchView/GitRepositorySearchViewController.swift
@@ -1,5 +1,5 @@
 //
-//  GitRepositoryListViewController.swift
+//  GitRepositorySearchViewController.swift
 //  iOSEngineerCodeCheck
 //
 //  Created by 史 翔新 on 2020/04/20.
@@ -8,8 +8,8 @@
 
 import UIKit
 
-class GitRepositoryListViewController: UIViewController {
-    private typealias ElementID = GitRepositoryListViewElementID
+class GitRepositorySearchViewController: UIViewController {
+    private typealias ElementID = GitRepositorySearchViewElementID
     
     // MARK: UI
     private var searchSettingBarButton: UIBarButtonItem!
@@ -56,10 +56,10 @@ class GitRepositoryListViewController: UIViewController {
     }()
     
     // MARK: 依存
-    private var presenter: GitRepositoryListPresenterInput!
+    private var presenter: GitRepositorySearchPresenterInput!
     
     // MARK: メソッド
-    func inject(presenter: GitRepositoryListPresenterInput) {
+    func inject(presenter: GitRepositorySearchPresenterInput) {
         self.presenter = presenter
     }
     
@@ -141,7 +141,7 @@ class GitRepositoryListViewController: UIViewController {
     }
 }
 
-extension GitRepositoryListViewController: UITableViewDataSource {
+extension GitRepositorySearchViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return presenter.gitRepositories.count
     }
@@ -158,7 +158,7 @@ extension GitRepositoryListViewController: UITableViewDataSource {
     }
 }
 
-extension GitRepositoryListViewController: UITableViewDelegate {
+extension GitRepositorySearchViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         let vc = GitRepositoryDetailViewController(
@@ -169,7 +169,7 @@ extension GitRepositoryListViewController: UITableViewDelegate {
     }
 }
 
-extension GitRepositoryListViewController: UISearchBarDelegate {
+extension GitRepositorySearchViewController: UISearchBarDelegate {
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
         presenter.searchBar(textDidChange: searchText)
     }
@@ -194,14 +194,14 @@ extension GitRepositoryListViewController: UISearchBarDelegate {
     }
 }
 
-extension GitRepositoryListViewController: UIPopoverPresentationControllerDelegate {
+extension GitRepositorySearchViewController: UIPopoverPresentationControllerDelegate {
     // iPhoneでPopoverを表示するために必要
     func adaptivePresentationStyle(for controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {
         return .none
     }
 }
 
-extension GitRepositoryListViewController: SearchSettingPopoverViewDelegate {
+extension GitRepositorySearchViewController: SearchSettingPopoverViewDelegate {
     var currentSortOption: GitRepositorySortOption {
         presenter.sortOption
     }
@@ -211,7 +211,7 @@ extension GitRepositoryListViewController: SearchSettingPopoverViewDelegate {
     }
 }
 
-extension GitRepositoryListViewController: GitRepositoryListPresenterOutput {
+extension GitRepositorySearchViewController: GitRepositorySearchPresenterOutput {
     func showRetryOrCancelAlert(title: String, message: String?) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         let retry = UIAlertAction(title: "再試行", style: .default) { _ in
@@ -259,8 +259,8 @@ extension GitRepositoryListViewController: GitRepositoryListPresenterOutput {
 }
 
 #Preview("UIKit") {
-    let vc = GitRepositoryListViewController()
-    let presenter = GitRepositoryListPresenter(
+    let vc = GitRepositorySearchViewController()
+    let presenter = GitRepositorySearchPresenter(
         view: vc,
         gitRepositorySearcher: GitRepositorySearcher()
     )

--- a/iOSEngineerCodeCheck/GitRepositorySearchView/GitRepositorySearchViewElementID.swift
+++ b/iOSEngineerCodeCheck/GitRepositorySearchView/GitRepositorySearchViewElementID.swift
@@ -1,5 +1,5 @@
 //
-//  GitRepositoryListViewElementID.swift
+//  GitRepositorySearchViewElementID.swift
 //  iOSEngineerCodeCheck
 //  
 //  Created by Seigetsu on 2023/12/26
@@ -9,7 +9,7 @@
 import Foundation
 
 /// UITestのために設定する accessibilityIdentifier をまとめたもの。
-enum GitRepositoryListViewElementID {
+enum GitRepositorySearchViewElementID {
     static let searchSettingBarButton = "Git Repository Search Setting Bar Button"
     static let searchBar = "Git Repository Search Bar"
     static let tableView = "Git Repository List Table"

--- a/iOSEngineerCodeCheck/SceneDelegate.swift
+++ b/iOSEngineerCodeCheck/SceneDelegate.swift
@@ -15,8 +15,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(frame: windowScene.coordinateSpace.bounds)
         window?.windowScene = windowScene
-        let rootVC = GitRepositoryListViewController()
-        let presenter = GitRepositoryListPresenter(view: rootVC, gitRepositorySearcher: GitRepositorySearcher())
+        let rootVC = GitRepositorySearchViewController()
+        let presenter = GitRepositorySearchPresenter(view: rootVC, gitRepositorySearcher: GitRepositorySearcher())
         rootVC.inject(presenter: presenter)
         window?.rootViewController = UINavigationController(rootViewController: rootVC)
         window?.makeKeyAndVisible()

--- a/iOSEngineerCodeCheckTests/Dummy/View/MockGitRepositorySearchViewController.swift
+++ b/iOSEngineerCodeCheckTests/Dummy/View/MockGitRepositorySearchViewController.swift
@@ -1,5 +1,5 @@
 //
-//  MockGitRepositoryListViewController.swift
+//  MockGitRepositorySearchViewController.swift
 //  iOSEngineerCodeCheckTests
 //  
 //  Created by Seigetsu on 2023/12/26
@@ -9,9 +9,9 @@
 import Foundation
 @testable import iOSEngineerCodeCheck
 
-class MockGitRepositoryListViewController: GitRepositoryListPresenterOutput {
+class MockGitRepositorySearchViewController: GitRepositorySearchPresenterOutput {
     // MARK: Presenter
-    private var presenter: GitRepositoryListPresenterInput!
+    private var presenter: GitRepositorySearchPresenterInput!
     
     // MARK: Called Flag
     private(set) var searchBarEndEditingCalled = false
@@ -27,7 +27,7 @@ class MockGitRepositoryListViewController: GitRepositoryListPresenterOutput {
     var showingGuidance = true
     
     // MARK: メソッド
-    func inject(presenter: GitRepositoryListPresenterInput) {
+    func inject(presenter: GitRepositorySearchPresenterInput) {
         self.presenter = presenter
     }
     

--- a/iOSEngineerCodeCheckTests/GitRepositorySearchPresenterTests.swift
+++ b/iOSEngineerCodeCheckTests/GitRepositorySearchPresenterTests.swift
@@ -1,5 +1,5 @@
 //
-//  GitRepositoryListPresenterTests.swift
+//  GitRepositorySearchPresenterTests.swift
 //  iOSEngineerCodeCheckTests
 //  
 //  Created by Seigetsu on 2023/12/26
@@ -9,18 +9,18 @@
 import XCTest
 @testable import iOSEngineerCodeCheck
 
-final class GitRepositoryListPresenterTests: XCTestCase {
+final class GitRepositorySearchPresenterTests: XCTestCase {
     // MARK: テスト対象
-    private var presenter: GitRepositoryListPresenter!
+    private var presenter: GitRepositorySearchPresenter!
     
     // MARK: ダミー
-    private var view: MockGitRepositoryListViewController!
+    private var view: MockGitRepositorySearchViewController!
     private var gitRepositorySearcher: MockGitRepositorySearcher!
     private var dummyGitRepositories = DummyGitRepositoryMaker.make(count: 3)
     
     // MARK: セットアップ
     override func setUp() {
-        view = MockGitRepositoryListViewController()
+        view = MockGitRepositorySearchViewController()
         gitRepositorySearcher = MockGitRepositorySearcher(
             result: .success(
                 GitRepositorySearchResult(
@@ -29,7 +29,7 @@ final class GitRepositoryListPresenterTests: XCTestCase {
             ),
             returningInterval: 0.1
         )
-        presenter = GitRepositoryListPresenter(
+        presenter = GitRepositorySearchPresenter(
             view: view,
             gitRepositorySearcher: gitRepositorySearcher
         )


### PR DESCRIPTION
単に Git リポジトリを一覧表示する画面というよりは、検索をするための画面という意味合いを含めた方が良さそう。