### PR TITLE
Feature: アラートキャンセル時にガイダンスを再表示

### DIFF
--- a/iOSEngineerCodeCheck/GitRepositorySearchView/GitRepositorySearchPresenter.swift
+++ b/iOSEngineerCodeCheck/GitRepositorySearchView/GitRepositorySearchPresenter.swift
@@ -131,6 +131,9 @@ extension GitRepositorySearchPresenter: GitRepositorySearchPresenterInput {
         Task {
             await MainActor.run {
                 view.stopActivityIndicator()
+                if textDidSearch == nil {
+                    view.showGuidance()
+                }
             }
         }
     }

--- a/iOSEngineerCodeCheck/GitRepositorySearchView/GitRepositorySearchPresenterOutput.swift
+++ b/iOSEngineerCodeCheck/GitRepositorySearchView/GitRepositorySearchPresenterOutput.swift
@@ -35,4 +35,7 @@ protocol GitRepositorySearchPresenterOutput: AnyObject {
     
     /// サーチバーへの入力を促すガイダンス表示を隠す。
     func hideGuidance()
+    
+    /// サーチバーへの入力を促すガイダンス表示を出す。
+    func showGuidance()
 }

--- a/iOSEngineerCodeCheck/GitRepositorySearchView/GitRepositorySearchViewController.swift
+++ b/iOSEngineerCodeCheck/GitRepositorySearchView/GitRepositorySearchViewController.swift
@@ -256,6 +256,10 @@ extension GitRepositorySearchViewController: GitRepositorySearchPresenterOutput 
     func hideGuidance() {
         guidanceLabel.isHidden = true
     }
+    
+    func showGuidance() {
+        guidanceLabel.isHidden = false
+    }
 }
 
 #Preview("UIKit") {

--- a/iOSEngineerCodeCheckTests/Dummy/View/MockGitRepositorySearchViewController.swift
+++ b/iOSEngineerCodeCheckTests/Dummy/View/MockGitRepositorySearchViewController.swift
@@ -66,4 +66,8 @@ class MockGitRepositorySearchViewController: GitRepositorySearchPresenterOutput 
     func hideGuidance() {
         showingGuidance = false
     }
+    
+    func showGuidance() {
+        showingGuidance = true
+    }
 }

--- a/iOSEngineerCodeCheckTests/GitRepositorySearchPresenterTests.swift
+++ b/iOSEngineerCodeCheckTests/GitRepositorySearchPresenterTests.swift
@@ -161,6 +161,7 @@ final class GitRepositorySearchPresenterTests: XCTestCase {
         
         _ = XCTWaiter.wait(for: [expectation(description: "Viewが読み込み状態になるまで待機")], timeout: 0.05)
         XCTAssertFalse(view.activityIndicatorAnimating)
+        XCTAssertTrue(view.showingGuidance)
     }
     
     func test_ソートオプション選択() {


### PR DESCRIPTION
初回の検索時にアラートが出てキャンセルを押した時に画面に何も表示されなくなるので、その場合はガイダンスの表示を再び出現させることにした。